### PR TITLE
Update project to require maven 3.6.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,6 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Setup Maven
-      run: mvn -N --ntp -V -e -B -C io.takari:maven:wrapper -Dmaven=3.6.0
+      run: mvn -N --ntp -V -e -B -C io.takari:maven:wrapper -Dmaven=3.6.3
     - name: Build with Maven
       run: ./mvnw -V -e -B -C clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!-- 
- - Copyright (c) 2013-2021 Polago AB
+ - Copyright (c) 2013-2024 Polago AB
  - All rights reserved.
  - 
  - Permission is hereby granted, free of charge, to any person obtaining
@@ -39,11 +39,11 @@
 
   <properties>
     <jdkVersion>1.8</jdkVersion>
-    <mavenVersion>3.6.0</mavenVersion>
+    <mavenVersion>3.6.3</mavenVersion>
     <surefireVersion>3.2.5</surefireVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <copyrightYear>2013-2021</copyrightYear>
+    <copyrightYear>2013-2024</copyrightYear>
     <copyrightMessage>Copyright (C) ${copyrightYear} Polago AB</copyrightMessage>
     <mainClass>org.polago.deployconf.DeployConfRunner</mainClass>
   </properties>


### PR DESCRIPTION
Version 3.6.3 is now required by maven-shade-plugin 3.5.2